### PR TITLE
khepri_mnesia_migration.app: Do not depend on Mnesia or Khepri

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
 {dialyzer, [{warnings, [underspecs,
                         unknown,
                         unmatched_returns]},
-            {plt_extra_apps, [mnesia]}]}.
+            {plt_extra_apps, [mnesia, khepri]}]}.
 
 {xref_checks, [undefined_function_calls,
                undefined_functions,
@@ -59,6 +59,7 @@
                                   cth_readable, %% <-- See comment above.
                                   edoc,
                                   eunit,
+                                  khepri,
                                   mnesia,
                                   ra,
                                   tools]}]} %% <-- For `cover`.

--- a/src/khepri_mnesia_migration.app.src
+++ b/src/khepri_mnesia_migration.app.src
@@ -7,9 +7,7 @@
   {mod, {khepri_mnesia_migration_app, []}},
   {applications,
    [kernel,
-    stdlib,
-    mnesia,
-    khepri
+    stdlib
    ]},
   {env,[]},
   {files, [


### PR DESCRIPTION
### Why

khepri_mnesia_migration obviously relies on Mnesia and Khepri to perform its task. However, we don't want to explicitly depend on them because in an Erlang release, this will cause Mnesia and Khepri to be started automatically by default.

Given the context where this application is used, it possible the user does not want both to be running at all time. Therefore, we leave them alone. The user of khepri_mnesia_migration already depends on Mnesia and Khepri. Thus we let the user handle the dependency and the start of Mnesia and Khepri.

### How

Mnesia and Khepri are removed from the `applications` entry in the app(4) file.

We add `khepri` to the `plt_extra_apps` configuration parameter in `rebar.config` so that Dialyzer still knows about it.