### PR TITLE
Run all migration callbacks in the m2k_table_copy server

### DIFF
--- a/src/m2k_subscriber.erl
+++ b/src/m2k_subscriber.erl
@@ -18,8 +18,7 @@
 
 -export([start_link/1,
          subscribe/2,
-         flush/2,
-         make_tables_readwrite/1]).
+         drain/1]).
 -export([init/1,
          handle_call/3,
          handle_cast/2,
@@ -33,8 +32,8 @@
 subscribe(Pid, Tables) ->
     gen_server:call(Pid, {?FUNCTION_NAME, Tables}, infinity).
 
-flush(Pid, ModPriv) ->
-    gen_server:call(Pid, {?FUNCTION_NAME, ModPriv}, infinity).
+drain(Pid) ->
+    gen_server:call(Pid, ?FUNCTION_NAME, infinity).
 
 start_link(Args) ->
     gen_server:start_link(?MODULE, Args, []).
@@ -51,14 +50,10 @@ init(#{converter_mod := Mod}) ->
 handle_call({subscribe, Tables}, _From, State) ->
     {Ret, State1} = do_subscribe(Tables, State),
     {reply, Ret, State1};
-handle_call({flush, ModPriv}, _From, State) ->
-    try
-        {ModPriv1, State1} = do_flush(ModPriv, State),
-        {reply, {ok, ModPriv1}, State1}
-    catch
-        throw:Error ->
-            {reply, Error, State}
-    end;
+handle_call(drain, _From, #?MODULE{events = Events} = State) ->
+    State1 = State#?MODULE{events = []},
+    State2 = do_unsubscribe(State1),
+    {reply, lists:reverse(Events), State2};
 handle_call(Request, _From, State) ->
     ?LOG_WARNING(
        ?MODULE_STRING ": Unhandled handle_call message: ~p",
@@ -161,108 +156,3 @@ do_unsubscribe1([Table | Rest]) ->
     end;
 do_unsubscribe1([]) ->
     ok.
-
-do_flush(ModPriv, #?MODULE{subscribed_to = SubscribedTo} = State) ->
-    %% Switch all tables to read-only. All concurrent and future Mnesia
-    %% transactions involving a write to one of them will fail with the
-    %% `{no_exists, Table}' exception.
-    make_tables_readonly(SubscribedTo),
-
-    try
-        %% Unsubscribe to Mnesia events. All Mnesia tables are read-only at
-        %% this point.
-        State1 = do_unsubscribe(State),
-
-        %% During the first round of copy, we received all write events as
-        %% messages (parallel writes were authorized). Now, we want to consume
-        %% those messages to record the writes we probably missed.
-        {ModPriv1, State2} = consume_mnesia_events(
-                               SubscribedTo, ModPriv, State1),
-        {ModPriv1, State2}
-    catch
-        Class:Reason:Stacktrace ->
-            make_tables_readwrite(SubscribedTo),
-            erlang:raise(Class, Reason, Stacktrace)
-    end.
-
-make_tables_readonly(Tables) ->
-    make_tables_readonly(Tables, []).
-
-make_tables_readonly([Table | Rest], AlreadyMarked) ->
-    ?LOG_DEBUG(
-       "Mnesia->Khepri data copy: mark Mnesia table `~ts` as read-only",
-       [Table],
-       #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
-    case mnesia:change_table_access_mode(Table, read_only) of
-        {atomic, ok} ->
-            make_tables_readonly(Rest, [Table | AlreadyMarked]);
-        {aborted, {already_exists, _, read_only}} ->
-            make_tables_readonly(Rest, [Table | AlreadyMarked]);
-        {aborted, _} = Error ->
-            _ = make_tables_readwrite(AlreadyMarked),
-            throw(Error)
-    end;
-make_tables_readonly([], _AlreadyMarked) ->
-    ok.
-
-make_tables_readwrite([Table | Rest]) ->
-    ?LOG_DEBUG(
-       "Mnesia->Khepri data copy: mark Mnesia table `~ts` as read-write after "
-       "a failed copy or a rollback",
-       [Table],
-       #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
-    _ = mnesia:change_table_access_mode(Table, read_write),
-    make_tables_readwrite(Rest);
-make_tables_readwrite([]) ->
-    ok.
-
-consume_mnesia_events(
-  Tables,
-  ModPriv,
-  #?MODULE{converter_mod = Mod,
-           events = Events} = State) ->
-    Events1 = lists:reverse(Events),
-    ?LOG_DEBUG(
-       "Mnesia->Khepri data copy: consuming ~b Mnesia events from tables ~0p",
-       [length(Events1), Tables],
-       #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
-    ModPriv1 = consume_mnesia_events1(Events1, Mod, ModPriv),
-    State1 = State#?MODULE{events = []},
-    {ModPriv1, State1}.
-
-consume_mnesia_events1([{put, Table, Record} | Rest], Mod, ModPriv) ->
-    case Mod:copy_to_khepri(Table, Record, ModPriv) of
-        {ok, ModPriv1} ->
-            Remaining = length(Rest),
-            if
-                Remaining rem 100 =:= 0 ->
-                    ?LOG_DEBUG(
-                       "Mnesia->Khepri data copy: ~b Mnesia events left",
-                       [Remaining],
-                       #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN});
-                true ->
-                    ok
-            end,
-            consume_mnesia_events1(Rest, Mod, ModPriv1);
-        Error ->
-            throw(Error)
-    end;
-consume_mnesia_events1([{delete, Table, Key} | Rest], Mod, ModPriv) ->
-    case Mod:delete_from_khepri(Table, Key, ModPriv) of
-        {ok, ModPriv1} ->
-            Remaining = length(Rest),
-            if
-                Remaining rem 100 =:= 0 ->
-                    ?LOG_DEBUG(
-                       "Mnesia->Khepri data copy: ~b Mnesia events left",
-                       [Remaining],
-                       #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN});
-                true ->
-                    ok
-            end,
-            consume_mnesia_events1(Rest, Mod, ModPriv1);
-        Error ->
-            throw(Error)
-    end;
-consume_mnesia_events1([], _Mod, ModPriv) ->
-    ModPriv.

--- a/src/mnesia_to_khepri_converter.erl
+++ b/src/mnesia_to_khepri_converter.erl
@@ -7,6 +7,9 @@
 
 %% @doc Behavior defining converter modules used during Mnesia->Khepri copy.
 %%
+%% All callbacks are run in the same process, so process-based features like
+%% the dictionary and mailbox are usable from the callback functions.
+%%
 %% Unlike what the "optional callback functions" line says above, at least
 %% one of {@link init_copy_to_khepri/3} or {@link init_copy_to_khepri/4} is
 %% required, depending on how the copy is started.


### PR DESCRIPTION
This change refactors `m2k_export` and `m2k_subscriber` to delegate all calls of `mnesia_to_khepri_converter` callbacks to the `m2k_table_copy` gen_server. `m2k_table_copy` then becomes responsible for tracking the converter module's opaque state. This allows converter modules to take advantage of single-process utilities like the process dictionary, process-owned ETS tables, the process mailbox, etc..

RabbitMQ server will take advantage of this to batch changes in Khepri via the `async` command option. Batching changes significantly improves migration throughput compared to synchronous calls since Ra can record more changes per call to fsync, and fsync appears to be the most costly bottleneck in large migrations.