### PR TITLE
mnesia_to_khepri: Support stopped Khepri store in `is_migration_finished/2`

### DIFF
--- a/test/mnesia_to_khepri_table_copy_SUITE.erl
+++ b/test/mnesia_to_khepri_table_copy_SUITE.erl
@@ -589,6 +589,13 @@ is_migration_finished_works(Config) ->
     StoreId = RaSystem,
     MigrationId = store_id_to_mig_id(StoreId),
 
+    %% `is_migration_finished/2' works even if the given store is unavailable.
+    ?assertEqual(
+       false,
+       erpc:call(
+         Node1,
+         mnesia_to_khepri, is_migration_finished, [StoreId, MigrationId])),
+
     ?assertEqual(
        {ok, StoreId},
        rpc:call(Node1, khepri, start, [RaSystem, StoreId])),


### PR DESCRIPTION
## Why

`is_migration_finished/{1,2}` and `handle_fallback/{3,4}` could be used before Khepri is even configured. Therefore, it should support the fact that the Khepri store might be stopped.

Without this, we get an exception because we try to set a projection up with an unavailable store.

## How

We look up the name of the given store in the list of running stores.