### PR TITLE
mnesia_to_khepri: Protect against infinite loop in `handle_fallback/4`

### DIFF
--- a/test/handle_fallback.erl
+++ b/test/handle_fallback.erl
@@ -1,0 +1,24 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2023 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(handle_fallback).
+
+-include_lib("eunit/include/eunit.hrl").
+
+can_detect_infinite_loop_test() ->
+    ok = mnesia:start(),
+    Table = some_table,
+    ?assertEqual(
+       {aborted, {no_exists, Table}},
+       mnesia_to_khepri:handle_fallback(
+         %% No need for a store, `is_migration_finished()' will return false.
+         non_existing_store,
+         <<"id">>,
+         fun() ->
+                 mnesia:transaction(fun() -> mnesia:read(Table, some_key) end)
+         end,
+         ok)).


### PR DESCRIPTION
## Why

If the Mnesia function fails because a Mnesia table does not exist for real and this error is unrelated to a migration to Khepri, `handle_fallback/4` will enter an infinite loop with a quick repetition.

With debug messages enabled, this causes many many stacktraces to be logged.

## How

We just count the number of times the Mnesia function fails with a `no_exists` reason. After 100 attempts, we stop retrying.