### PR TITLE
mnesia_to_khepri: Check record validity before calling `Mod:copy_to_khepri/3`

### DIFF
--- a/test/kmm_gen_servers.erl
+++ b/test/kmm_gen_servers.erl
@@ -22,6 +22,9 @@ m2k_subscriber_test() ->
     test_gen_server(Module).
 
 test_gen_server(Module) ->
+    ok = mnesia:start(),
+    {atomic, ok} = mnesia:create_table(Module, []),
+
     RaSystem = Module,
     StoreId = RaSystem,
     StoreDir = helpers:store_dir_name(RaSystem),


### PR DESCRIPTION
## Why

It appears that we get Mnesia write events with the table name and the key, instead of the table name and the written record. The expected event seems to come after.

We can't do anything with just the key and we want to skip calls to the callback module in this case.

## How

To distinguish the key from the expected record, we first query the table info to get the record name and its arity. Then, we verify the received term against the queried record definition to check if the term is a valid record before calling `Mod:copy_to_khepri/3`.