### PR TITLE
m2k_table_copy: Handle existing projection

### DIFF
--- a/src/m2k_table_copy.erl
+++ b/src/m2k_table_copy.erl
@@ -95,6 +95,14 @@ is_migration_finished1(StoreId, MigrationId) ->
             case setup_projection(StoreId, ProjectionName) of
                 ok ->
                     is_migration_finished1(StoreId, MigrationId);
+                %% Before Khepri v0.13.0, `khepri:register_projection/1,2,3`
+                %% would return `{error, exists}` for projections which already
+                %% exist.
+                {error, exists} ->
+                    is_migration_finished1(StoreId, MigrationId);
+                %% In v0.13.0+, Khepri returns a `?khepri_error(..)` instead.
+                {error, {khepri, projection_already_exists, _Info}} ->
+                    is_migration_finished1(StoreId, MigrationId);
                 Error ->
                     ?LOG_WARNING(
                        "Mnesia->Khepri data copy: failed to setup Khepri "


### PR DESCRIPTION
## Why

Thanks to concurrency, it's possible that the projection is created between the attempt to use it and the call to `setup_projection/2`. If this happens, the setup fails with an error telling the projection already exists.

This is not a fatal error, we should simply retry to read the projection's table.

## How

We handle both the old and the new possible "projection already exists" error terms and retry the function if this occurs.