### PR TITLE
Improve logging in `is_migration_finished/2` and `handle_fallback/4`

### DIFF
--- a/src/m2k_table_copy.erl
+++ b/src/m2k_table_copy.erl
@@ -104,11 +104,11 @@ is_migration_finished1(StoreId, MigrationId) ->
                 {error, {khepri, projection_already_exists, _Info}} ->
                     is_migration_finished1(StoreId, MigrationId);
                 Error ->
-                    ?LOG_WARNING(
-                       "Mnesia->Khepri data copy: failed to setup Khepri "
-                       "projection for migration \"~ts\", expect slower "
-                       "versions of `is_migration_finished()` and "
-                       "`handle_fallback()`~n~p",
+                    ?LOG_INFO(
+                       "Mnesia/Khepri backend selection: couldn't setup Khepri "
+                       "projection for migration \"~ts\"; that's ok but expect "
+                       "slightly slower versions of `is_migration_finished()` "
+                       "and `handle_fallback()`~n~p",
                        [MigrationId, Error],
                        #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
                     is_migration_finished_slow(StoreId, MigrationId)

--- a/src/m2k_table_copy.erl
+++ b/src/m2k_table_copy.erl
@@ -104,13 +104,21 @@ is_migration_finished1(StoreId, MigrationId) ->
                 {error, {khepri, projection_already_exists, _Info}} ->
                     is_migration_finished1(StoreId, MigrationId);
                 Error ->
-                    ?LOG_INFO(
-                       "Mnesia/Khepri backend selection: couldn't setup Khepri "
-                       "projection for migration \"~ts\"; that's ok but expect "
-                       "slightly slower versions of `is_migration_finished()` "
-                       "and `handle_fallback()`~n~p",
-                       [MigrationId, Error],
-                       #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
+                    Key = {?MODULE, ?FUNCTION_NAME, StoreId},
+                    case persistent_term:get(Key, undefined) of
+                        Error ->
+                            ok;
+                        _ ->
+                            ?LOG_INFO(
+                               "Mnesia->Khepri fallback handling: couldn't "
+                               "setup Khepri projection for migration "
+                               "\"~ts\"; that's ok but expect slightly "
+                               "slower versions of `is_migration_finished()` "
+                               "and `handle_fallback()`~n~p",
+                               [MigrationId, Error],
+                               #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
+                            persistent_term:put(Key, Error)
+                    end,
                     is_migration_finished_slow(StoreId, MigrationId)
             end
     end.


### PR DESCRIPTION
## Why

If we failed to setup the projection, we used to log a LOT and at the "warning" level on top of that. This was scary and spammy for no good reason because the function works just fine even without the projection.

## How

Now, the function logs at the "info" level and only once per error.