### PR TITLE
m2k_cluster_sync: Tolerate that a node is down during sync

### DIFF
--- a/test/helpers.erl
+++ b/test/helpers.erl
@@ -252,7 +252,12 @@ start_erlang_node(Name) ->
     {Node, Peer}.
 
 stop_erlang_node(_Node, Peer) ->
-    ok = peer:stop(Peer).
+    try
+        ok = peer:stop(Peer)
+    catch
+        _:noproc ->
+            ok
+    end.
 -else.
 start_erlang_node(Name) ->
     Name1 = list_to_atom(Name),

--- a/test/mnesia_to_khepri_cluster_sync_SUITE.erl
+++ b/test/mnesia_to_khepri_cluster_sync_SUITE.erl
@@ -480,7 +480,7 @@ can_recreate_khepri_cluster_after_losing_one_node(Config) ->
     %% Stop Khepri store on node 1 and reset it.
     ct:pal("Stopping and \"losing\" a node"),
     [LostNode | _] = Nodes,
-    LostNodeProps = maps:get(SomeNode, PropsPerNode),
+    LostNodeProps = maps:get(LostNode, PropsPerNode),
     erpc:call(LostNode, mnesia, stop, []),
     erpc:call(LostNode, khepri, stop, [StoreId]),
     LostNodeProps1 = erpc:call(


### PR DESCRIPTION
## Why

In commit 52d3e5660f752d5a533af91906db7ffb0c22d73b, we handled the situation where a node lost its data and we tried to sync the cluster.

This patch was not enough if we lose sevenal nodes because some of them might be still down, or the Khepri store might not run yet. In this case, the sync fails because it can't remove those nodes from the cluster.

## How

This patch does two things in `remove_nodes_from_khepri_cluster/2`:
* It switches to use `erpc` and catches the fact that the remote node could be unreachable.
* It handles the `not_a_khepri_store` error.

In both cases, it ignores and skips that node which should have beer removed and just log a message.