### PR TITLE
m2k_table_copy: Handle the "delete" backup items

### DIFF
--- a/src/m2k_export.erl
+++ b/src/m2k_export.erl
@@ -76,7 +76,8 @@ write(
              after
                  15_000 ->
                      ?LOG_ERROR(
-                        "Mnesia->Khepri data copy: [" ?MODULE_STRING "] timeout: record/~0p",
+                        "Mnesia->Khepri data copy: [" ?MODULE_STRING "] "
+                        "timeout: record/~0p",
                         [Record],
                         #{domain => ?KMM_M2K_TABLE_COPY_LOG_DOMAIN}),
                      {error, timeout}

--- a/src/mnesia_to_khepri.erl
+++ b/src/mnesia_to_khepri.erl
@@ -55,6 +55,7 @@
 
 -include_lib("kernel/include/logger.hrl").
 
+-include("src/kmm_error.hrl").
 -include("src/kmm_logging.hrl").
 
 -export([sync_cluster_membership/0, sync_cluster_membership/1,


### PR DESCRIPTION
## Why

The Mnesia Backup and Restore callback API states that the callback module must provide the following function:

```erlang
write(Priv, BackupItems)
```

`BackupItems` can be among other values:
* `{Record}` to pass a record that is present in the table
* `{Table, Key}` to pass a record that should be deleted

Unlike what the docs state, the passed record present in the table is passed as `Record`; in other words, it is not wrapped in a tuple. This is not really a problem because a size-2 record is not allowed to be used to define a Mnesia table schema.

Our testsuite never met a case where the `{Table, Key}` to delete is passed to the callback module. However it happens in RabbitMQ when a lot of queues are declared in parallel of the migration.

Before this patch, khepri_mnesia_migration would consider this term an invalid record and would ignore it. That is incorrect and the key should be deleted instead.

## How

Now, `m2k_table_copy` calls its own callback module's `delete_from_khepri()` function if the backup item is `{Table, Key}`, and calls `copy_to_khepri()` otherwise.