### PR TITLE
Fix compatibility with Khepri 0.16.0

### DIFF
--- a/src/m2k_cluster_sync.erl
+++ b/src/m2k_cluster_sync.erl
@@ -211,7 +211,7 @@ locally_known_members(Node, StoreId) ->
         erpc:call(
           Node, khepri_cluster, members, [StoreId, #{favor => low_latency}])
     catch
-        error:{exception, undef, [{khepri_cluster, members, _, _} | _]} ->
+        error:{exception, function_clause, _} ->
             erpc:call(
               Node, khepri_cluster, locally_known_members, [StoreId])
     end.


### PR DESCRIPTION
## Why

`khepri_cluster:members/2` exists in Khepri 0.16.0. We get a `function_clause` exception, not an `undef`.

While here, re-enable the cluster repair tests after making an improvement to eliminate the risk of a test transient failure.