### PR TITLE
m2k_cluster_sync: Sort clusters by Khepri machine version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -54,7 +54,8 @@
             %% extra app for Dialyzer. That's because Rebar is using that
             %% application to override `ct:pal()' and Dialyzer complains it
             %% doesn't know this application.
-            cth_readable]},
+            cth_readable,
+            meck]},
     {dialyzer, [{plt_extra_apps, [common_test,
                                   cth_readable, %% <-- See comment above.
                                   edoc,

--- a/src/m2k_cluster_sync.erl
+++ b/src/m2k_cluster_sync.erl
@@ -329,19 +329,23 @@ discard_nodes_who_lost_their_data([], KhepriClusters, LostNodes) ->
               end
       end, KhepriClusters).
 
+-define(KHEPRI_MACHINE_VERSIONS_KEY, kmm_khepri_machine_versions).
 -define(TREE_NODES_COUNTS_KEY, kmm_tree_nodes_counts).
 -define(ERLANG_NODES_UPTIMES_KEY, kmm_erlang_node_uptimes).
 
 sort_khepri_clusters(KhepriClusters, StoreId) ->
+    _ = erlang:put(?KHEPRI_MACHINE_VERSIONS_KEY, #{}),
     _ = erlang:put(?TREE_NODES_COUNTS_KEY, #{}),
     _ = erlang:put(?ERLANG_NODES_UPTIMES_KEY, #{}),
     SortedNodes = do_sort_khepri_clusters(KhepriClusters, StoreId),
     _ = erlang:erase(?ERLANG_NODES_UPTIMES_KEY),
     _ = erlang:erase(?TREE_NODES_COUNTS_KEY),
+    _ = erlang:erase(?KHEPRI_MACHINE_VERSIONS_KEY),
     SortedNodes.
 
 do_sort_khepri_clusters(KhepriClusters, StoreId) ->
     Criterias = [fun compare_members_counts/3,
+                 fun compare_khepri_machine_versions/3,
                  fun compare_tree_nodes_counts/3,
                  fun compare_erlang_node_uptimes/3,
                  fun compare_erlang_node_names/3],
@@ -365,6 +369,14 @@ compare_members_counts(A, B, _StoreId) ->
         true                            -> length(A) > length(B)
     end.
 
+compare_khepri_machine_versions(A, B, _StoreId) ->
+    AMacVer = get_khepri_machine_versions(A),
+    BMacVer = get_khepri_machine_versions(B),
+    if
+        AMacVer =:= BMacVer -> undefined;
+        true                -> AMacVer < BMacVer
+    end.
+
 compare_tree_nodes_counts(A, B, StoreId) ->
     ANodesCount = get_tree_nodes_count(A, StoreId),
     BNodesCount = get_tree_nodes_count(B, StoreId),
@@ -383,6 +395,29 @@ compare_erlang_node_uptimes(A, B, _StoreId) ->
 
 compare_erlang_node_names(A, B, _StoreId) ->
     A =< B.
+
+get_khepri_machine_versions(Nodes) ->
+    KhepriMacVers = erlang:get(?KHEPRI_MACHINE_VERSIONS_KEY),
+    case KhepriMacVers of
+        #{Nodes := KhepriMacVer} ->
+            KhepriMacVer;
+        _ ->
+            Rets = erpc:multicall(Nodes, khepri_machine, version, []),
+            MacVers = lists:map(
+                        fun
+                            ({ok, MacVer}) ->
+                                MacVer;
+                            (_Error) ->
+                                ?kmm_misuse(
+                                   failed_to_query_khepri_machine_versions,
+                                   #{nodes => Nodes,
+                                     returns => Rets})
+                        end, Rets),
+            MacVer = lists:min(MacVers),
+            KhepriMacVers1 = KhepriMacVers#{Nodes => MacVer},
+            _ = erlang:put(?KHEPRI_MACHINE_VERSIONS_KEY, KhepriMacVers1),
+            MacVer
+    end.
 
 get_tree_nodes_count(Nodes, StoreId) ->
     TreeNodesCounts = erlang:get(?TREE_NODES_COUNTS_KEY),

--- a/src/m2k_cluster_sync.erl
+++ b/src/m2k_cluster_sync.erl
@@ -335,14 +335,14 @@ discard_nodes_who_lost_their_data([], KhepriClusters, LostNodes) ->
 sort_khepri_clusters(KhepriClusters, StoreId) ->
     _ = erlang:put(?TREE_NODES_COUNTS_KEY, #{}),
     _ = erlang:put(?ERLANG_NODES_UPTIMES_KEY, #{}),
-    SortedNodes = do_sort_khepri_clusters_by_size(KhepriClusters, StoreId),
+    SortedNodes = do_sort_khepri_clusters(KhepriClusters, StoreId),
     _ = erlang:erase(?ERLANG_NODES_UPTIMES_KEY),
     _ = erlang:erase(?TREE_NODES_COUNTS_KEY),
     SortedNodes.
 
-do_sort_khepri_clusters_by_size(KhepriClusters, StoreId) ->
-    Criterias = [fun compare_members_count/3,
-                 fun compare_tree_nodes_count/3,
+do_sort_khepri_clusters(KhepriClusters, StoreId) ->
+    Criterias = [fun compare_members_counts/3,
+                 fun compare_tree_nodes_counts/3,
                  fun compare_erlang_node_uptimes/3,
                  fun compare_erlang_node_names/3],
     lists:sort(
@@ -357,7 +357,7 @@ do_sort_khepri_clusters_by_size(KhepriClusters, StoreId) ->
       end,
       KhepriClusters).
 
-compare_members_count(A, B, _StoreId) ->
+compare_members_counts(A, B, _StoreId) ->
     AMembersCount = length(A),
     BMembersCount = length(B),
     if
@@ -365,7 +365,7 @@ compare_members_count(A, B, _StoreId) ->
         true                            -> length(A) > length(B)
     end.
 
-compare_tree_nodes_count(A, B, StoreId) ->
+compare_tree_nodes_counts(A, B, StoreId) ->
     ANodesCount = get_tree_nodes_count(A, StoreId),
     BNodesCount = get_tree_nodes_count(B, StoreId),
     if
@@ -418,12 +418,12 @@ get_longest_erlang_node_uptime(Nodes) ->
             Uptimes = lists:map(
                         fun
                             ({ok, Uptime}) ->
-                        Uptime;
-                    (_Error) ->
-                        ?kmm_misuse(
-                           failed_to_query_erlang_node_uptimes,
-                           #{nodes => Nodes,
-                             returns => Rets})
+                                Uptime;
+                            (_Error) ->
+                                ?kmm_misuse(
+                                   failed_to_query_erlang_node_uptimes,
+                                   #{nodes => Nodes,
+                                     returns => Rets})
                         end, Rets),
             Uptime = lists:max(Uptimes),
             NodeUptimes1 = NodeUptimes#{Nodes => Uptime},


### PR DESCRIPTION
## Why

If one of the node/cluster uses a lower Khepri machine version as other nodes/clusters, it could join a node/cluster running a newer version but it won’t be able to apply any command. This would render that node kind of useless.

## How

We now sort a node/cluster using the lower Khepri machine version first. This way, it will be used as the seed node/cluster for the sync.

The members count remains a more important criteria, so the largest cluster won't be dismantled to join a single node running an old Khepri machine version.

However, other criterias are less important.